### PR TITLE
Set pcretest stack size to 8MB on windows

### DIFF
--- a/pcreApp/src/Makefile
+++ b/pcreApp/src/Makefile
@@ -45,6 +45,9 @@ pcreposix_LIBS += pcre
 pcretest_SRCS += pcretest.c pcre_printint.c
 pcretest_LIBS += pcreposix pcre
 
+# Tests requires 8MB of stack, 1MB is the windows default
+pcretest_LDFLAGS_WIN32 += -stack:8388608
+
 pcre_jit_test_SRCS += pcre_jit_test.c
 pcre_jit_test_LIBS += pcreposix pcre
 

--- a/pcreApp/src/run_tests.bat
+++ b/pcreApp/src/run_tests.bat
@@ -2,8 +2,13 @@ setlocal
 set "srcdir=%~dp0..\..\pcre-src"
 set "pcretest=%~dp0..\..\bin\%EPICS_HOST_ARCH%\pcretest.exe"
 call %srcdir%\RunTest.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
 %~dp0..\..\bin\%EPICS_HOST_ARCH%\pcre_jit_test.exe
+if %errorlevel% neq 0 exit /b %errorlevel%
 %~dp0..\..\bin\%EPICS_HOST_ARCH%\pcrecpp_unittest.exe
+if %errorlevel% neq 0 exit /b %errorlevel%
 %~dp0..\..\bin\%EPICS_HOST_ARCH%\pcre_scanner_unittest.exe
+if %errorlevel% neq 0 exit /b %errorlevel%
 %~dp0..\..\bin\%EPICS_HOST_ARCH%\pcre_stringpiece_unittest.exe
+if %errorlevel% neq 0 exit /b %errorlevel%
 @echo done


### PR DESCRIPTION
Set stack size to 8MB when running `pcretest`

Prior to change, typing `make runtest` will print a message saying stack size needs to be 8MB and tests fail

After change and rebuild, message should go away and `make runtests` tests pass 
